### PR TITLE
Change import statements for all parsers

### DIFF
--- a/edscrapers/scrapers/edgov/parsers/__init__.py
+++ b/edscrapers/scrapers/edgov/parsers/__init__.py
@@ -1,3 +1,2 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.edgov.parsers.edgov_parser1 as parser1
+from edscrapers.scrapers.edgov.parsers import edgov_parser1 as parser1

--- a/edscrapers/scrapers/fsa/parsers/__init__.py
+++ b/edscrapers/scrapers/fsa/parsers/__init__.py
@@ -1,4 +1,3 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.fsa.parsers.fsa_parser1 as parser1
-import edscrapers.scrapers.fsa.parsers.fsa_parser2 as parser2
+from edscrapers.scrapers.fsa.parsers import fsa_parser1 as parser1
+from edscrapers.scrapers.fsa.parsers import fsa_parser2 as parser2

--- a/edscrapers/scrapers/nces/parsers/__init__.py
+++ b/edscrapers/scrapers/nces/parsers/__init__.py
@@ -1,6 +1,5 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.nces.parsers.nces_parser1 as parser1
-import edscrapers.scrapers.nces.parsers.nces_parser2 as parser2
-import edscrapers.scrapers.nces.parsers.nces_parser3 as parser3
-import edscrapers.scrapers.nces.parsers.nces_parser4 as parser4
+from edscrapers.scrapers.nces.parsers import nces_parser1 as parser1
+from edscrapers.scrapers.nces.parsers import nces_parser2 as parser2
+from edscrapers.scrapers.nces.parsers import nces_parser3 as parser3
+from edscrapers.scrapers.nces.parsers import nces_parser4 as parser4

--- a/edscrapers/scrapers/ocr/parsers/__init__.py
+++ b/edscrapers/scrapers/ocr/parsers/__init__.py
@@ -1,4 +1,3 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.ocr.parsers.ocr_state_national_estimates_parser1 as parser1
-import edscrapers.scrapers.ocr.parsers.ocr_state_national_estimates_parser2 as parser2
+from edscrapers.scrapers.ocr.parsers import ocr_state_national_estimates_parser1 as parser1
+from edscrapers.scrapers.ocr.parsers import ocr_state_national_estimates_parser2 as parser2

--- a/edscrapers/scrapers/octae/parsers/__init__.py
+++ b/edscrapers/scrapers/octae/parsers/__init__.py
@@ -1,4 +1,3 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.octae.parsers.octae_parser1 as parser1
-import edscrapers.scrapers.octae.parsers.octae_parser2 as parser2
+from edscrapers.scrapers.octae.parsers import octae_parser1 as parser1
+from edscrapers.scrapers.octae.parsers import octae_parser2 as parser2

--- a/edscrapers/scrapers/oela/parsers/__init__.py
+++ b/edscrapers/scrapers/oela/parsers/__init__.py
@@ -1,3 +1,2 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.oela.parsers.oela_parser1 as parser1
+from edscrapers.scrapers.oela.parsers import oela_parser1 as parser1

--- a/edscrapers/scrapers/oese/parsers/__init__.py
+++ b/edscrapers/scrapers/oese/parsers/__init__.py
@@ -1,3 +1,2 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.oese.parsers.oese_parser1 as parser1
+from edscrapers.scrapers.oese.parsers import oese_parser1 as parser1

--- a/edscrapers/scrapers/ope/parsers/__init__.py
+++ b/edscrapers/scrapers/ope/parsers/__init__.py
@@ -1,4 +1,3 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.ope.parsers.ope_parser1 as parser1
-import edscrapers.scrapers.ope.parsers.ope_parser2 as parser2
+from edscrapers.scrapers.ope.parsers import ope_parser1 as parser1
+from edscrapers.scrapers.ope.parsers import ope_parser2 as parser2

--- a/edscrapers/scrapers/opepd/parsers/__init__.py
+++ b/edscrapers/scrapers/opepd/parsers/__init__.py
@@ -1,4 +1,3 @@
-
 # import modules from this package with simplier names
-import edscrapers.scrapers.opepd.parsers.opepd_parser1 as parser1
-import edscrapers.scrapers.opepd.parsers.opepd_parser2 as parser2
+from edscrapers.scrapers.opepd.parsers import opepd_parser1 as parser1
+from edscrapers.scrapers.opepd.parsers import opepd_parser2 as parser2

--- a/edscrapers/scrapers/osers/parsers/__init__.py
+++ b/edscrapers/scrapers/osers/parsers/__init__.py
@@ -1,2 +1,2 @@
-import edscrapers.scrapers.osers.parsers.osers_parser1 as parser1
-import edscrapers.scrapers.osers.parsers.osers_parser2 as parser2
+from edscrapers.scrapers.osers.parsers import osers_parser1 as parser1
+from edscrapers.scrapers.osers.parsers import osers_parser2 as parser2


### PR DESCRIPTION
The import we had was breaking a new, fresh deployment on the AWS EC2 instance I created this morning. Applying this patch locally fixed it.